### PR TITLE
Update __init__.py

### DIFF
--- a/locate/__init__.py
+++ b/locate/__init__.py
@@ -5,3 +5,11 @@ from ._locate import (
     append_sys_path,
     prepend_sys_path,
 )
+
+__all__ = [
+    "this_dir",
+    "allow_relative_location_imports",
+    "force_relative_location_imports",
+    "append_sys_path",
+    "prepend_sys_path",
+]


### PR DESCRIPTION
Add an __all__ variable to see if Pylance will stopp giving this error: "this_dir" is not exported from module "locate" Pylance(reportPrivateImportUsage)